### PR TITLE
fix: use correct --format json flag in CI workflow

### DIFF
--- a/.github/workflows/decapod-validate.yml
+++ b/.github/workflows/decapod-validate.yml
@@ -28,7 +28,7 @@ jobs:
           DECAPOD_VALIDATE_SKIP_GIT_GATES: 1
         run: |
           decapod init --proof
-          TASK_ID=$(decapod todo add "CI validation" -o json 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+          TASK_ID=$(decapod todo add "CI validation" --format json 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
           decapod todo claim --id $TASK_ID
           WORKSPACE_OUTPUT=$(decapod workspace ensure 2>&1)
           WORKSPACE_DIR=$(echo "$WORKSPACE_OUTPUT" | grep -o '"worktree_path":"[^"]*"' | cut -d'"' -f4)


### PR DESCRIPTION
Fix CI workflow by using correct --format json flag instead of -o json